### PR TITLE
fix: Ensure the gauge is re-rendered if it was not displayed before

### DIFF
--- a/src/lib/GaugeComponent/index.tsx
+++ b/src/lib/GaugeComponent/index.tsx
@@ -78,6 +78,18 @@ const GaugeComponent = (props: Partial<GaugeComponentProps>) => {
   }, [props]);
 
   useEffect(() => {
+    const observer = new MutationObserver(function () {
+      if (!selectedRef.current?.offsetParent) return;
+
+      chartHooks.renderChart(gauge, true);
+      observer.disconnect()
+    });
+
+    observer.observe(window.document, {attributes: true, subtree: true});
+    return () => observer.disconnect();
+  }, [selectedRef.current?.parentNode]);
+
+  useEffect(() => {
     const handleResize = () => chartHooks.renderChart(gauge, true);
     //Set up resize event listener to re-render the chart everytime the window is resized
     window.addEventListener("resize", handleResize);


### PR DESCRIPTION
Referring to https://github.com/antoniolago/react-gauge-component/issues/40

I added a MutationObserver to the element to check if there's a parent container available (which is only the case if the element is not hidden via `display: none` on itself or one of the parent elements). This ensures that if the element becomes visible again, the re-rendering is being triggered. 

It works for my use case, but please give some feedback on performance and if it's also solving other people's problems.