### PR TITLE
Fixed tick text overlapping over tick line for certain values

### DIFF
--- a/src/lib/GaugeComponent/hooks/labels.ts
+++ b/src/lib/GaugeComponent/hooks/labels.ts
@@ -278,9 +278,7 @@ export const calculateAnchorAndAngleByValue = (value: number, gauge: Gauge) => {
   let { startAngle, endAngle } = gaugeTypesAngles[gauge.props.type as string];
 
   let angle = startAngle + (valuePercentage * 100) * endAngle / 100;
-  let halfInPercentage = utils.calculatePercentage(minValue, maxValue, (maxValue / 2));
-  let halfPercentage = halfInPercentage;
-  let isValueLessThanHalf = valuePercentage < halfPercentage;
+  let isValueLessThanHalf = valuePercentage < 0.5;
   //Values between 40% and 60% are aligned in the middle
   let isValueBetweenTolerance = valuePercentage > CONSTANTS.rangeBetweenCenteredTickValueLabel[0] &&
     valuePercentage < CONSTANTS.rangeBetweenCenteredTickValueLabel[1];

--- a/src/lib/GaugeComponent/hooks/utils.ts
+++ b/src/lib/GaugeComponent/hooks/utils.ts
@@ -4,7 +4,7 @@ export const calculatePercentage = (minValue: number, maxValue: number, value: n
   if (value < minValue) {
     return 0;
   } else if (value > maxValue) {
-    return 100;
+    return 1;
   } else {
     let percentage = (value - minValue) / (maxValue - minValue)
     return (percentage);


### PR DESCRIPTION
Hello, 

Thank you for the time you are spending to maintain this library. 

### How to reproduce the bug

This issue can be replicated using the following code : 

```
            <GaugeComponent
                type="semicircle"
                pointer={{type: "blob"}}
                labels={{
                    valueLabel: {
                        style: {
                            fontSize: "50px",
                            // fontWeight: "",
                            textShadow: "",
                            fill: "#533B4D" // Setting the color
                        }
                    },
                    tickLabels: {
                        type: "outer",
                    }
                }}
                arc={{
                    subArcs:
                        [
                            {
                                limit: 7.2,
                                color: "#3D5467"
                            },
                            {
                                limit: 8.5,
                                color: "#F1EDEE"
                            },

                        ]
                }
                }
                value={7.2}
                maxValue={8.5}
                minValue={4.3}
            />

```

Notice how the minimum value overlaps with the tick mark due to the anchor being pinned to the opposite anchor point:
<img width="303" alt="Screenshot 2024-05-16 at 2 36 57 PM" src="https://github.com/antoniolago/react-gauge-component/assets/170017507/c5e05102-f92e-47c0-92a6-235d145dcb93">

For other values, for example minValue 4.1, the anchor is set correctly:

<img width="343" alt="Screenshot 2024-05-16 at 2 37 11 PM" src="https://github.com/antoniolago/react-gauge-component/assets/170017507/e348f84c-b622-41f0-b639-51a0febdfaef">

### Fix
After applying the fix, the anchor point should now be correctly determined by checking if the label is in the < 50% side of the semicircle. 

<img width="327" alt="Screenshot 2024-05-16 at 2 37 57 PM" src="https://github.com/antoniolago/react-gauge-component/assets/170017507/795f41c4-4ce9-45f1-8f2a-a7b0cf7f05ba">



### Notes
The change to ```utils.ts``` is not related to this bug. ```calculatePercentage``` is expected to return values between 0 and 1, but the ```value > maxValue``` branch was returning 100. 




 