### PR TITLE
Make the blob stroke width configurable property

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ const kbitsToMbits = (value) => {
         <li><code>animationDuration: number</code>: The duration of the pointer animation. Default: <code>3000</code></li>
         <li><code>animationDelay: number</code>: The delay of the pointer animation. Default: <code>100</code></li>
         <li><code>width: number</code>: The width of the pointer. Default: <code>20</code></li>
+        <li><code>strokeWidth: number</code>: Only available for blob type. Set the width of the stroke. Default is based on the blob width</li>
       </ul>
     </li>
     <li><code>labels: object</code>: The labels of the gauge.

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ const kbitsToMbits = (value) => {
         <li><code>animationDuration: number</code>: The duration of the pointer animation. Default: <code>3000</code></li>
         <li><code>animationDelay: number</code>: The delay of the pointer animation. Default: <code>100</code></li>
         <li><code>width: number</code>: The width of the pointer. Default: <code>20</code></li>
-        <li><code>strokeWidth: number</code>: Only available for blob type. Set the width of the stroke. Default is based on the blob width</li>
+        <li><code>strokeWidth: number</code>: Only available for blob type. Set the width of the stroke. Default: <code>8</code></li>
       </ul>
     </li>
     <li><code>labels: object</code>: The labels of the gauge.

--- a/src/TestComponent/MainPreviews.tsx
+++ b/src/TestComponent/MainPreviews.tsx
@@ -275,7 +275,7 @@ const MainPreviews = () => {
                                             {}
                                         ]
                                 }}
-                                pointer={{ type: "blob", animationDelay: 0, elastic: true }}
+                                pointer={{ type: "blob", animationDelay: 0, elastic: true, strokeWidth: 7 }}
                                 value={currentValue}
                             />
                         </Col>

--- a/src/lib/GaugeComponent/hooks/pointer.ts
+++ b/src/lib/GaugeComponent/hooks/pointer.ts
@@ -91,7 +91,7 @@ const initPointer = (gauge: Gauge) => {
             .attr("r", pointerRadius)
             .attr("fill", pointer.baseColor)
             .attr("stroke", pointer.color)
-            .attr("stroke-width", 8*pointerRadius/10);
+            .attr("stroke-width", pointer.strokeWidth ?? 8 * pointerRadius / 10);
     }
     //Translate the pointer starting point of the arc
     setPointerPosition(pointerRadius, value, gauge);
@@ -106,6 +106,7 @@ const updatePointer = (percentage: number, gauge: Gauge) => {
         let currentColor = arcHooks.getArcDataByPercentage(percentage, gauge)?.color as string;
         let shouldChangeColor = currentColor != prevColor;
         if(shouldChangeColor) gauge.pointer.current.element.select("circle").attr("stroke", currentColor)
+        gauge.pointer.current.element.select("circle").attr("stroke-width", pointer.strokeWidth ?? 8 * pointerRadius / 10);
         gauge.pointer.current.context.prevColor = currentColor;
     }
 }

--- a/src/lib/GaugeComponent/hooks/pointer.ts
+++ b/src/lib/GaugeComponent/hooks/pointer.ts
@@ -91,7 +91,7 @@ const initPointer = (gauge: Gauge) => {
             .attr("r", pointerRadius)
             .attr("fill", pointer.baseColor)
             .attr("stroke", pointer.color)
-            .attr("stroke-width", pointer.strokeWidth ?? 8 * pointerRadius / 10);
+            .attr("stroke-width", pointer.strokeWidth! * pointerRadius / 10);
     }
     //Translate the pointer starting point of the arc
     setPointerPosition(pointerRadius, value, gauge);
@@ -106,7 +106,7 @@ const updatePointer = (percentage: number, gauge: Gauge) => {
         let currentColor = arcHooks.getArcDataByPercentage(percentage, gauge)?.color as string;
         let shouldChangeColor = currentColor != prevColor;
         if(shouldChangeColor) gauge.pointer.current.element.select("circle").attr("stroke", currentColor)
-        gauge.pointer.current.element.select("circle").attr("stroke-width", pointer.strokeWidth ?? 8 * pointerRadius / 10);
+        gauge.pointer.current.element.select("circle").attr("stroke-width", pointer.strokeWidth! * pointerRadius / 10);
         gauge.pointer.current.context.prevColor = currentColor;
     }
 }

--- a/src/lib/GaugeComponent/hooks/pointer.ts
+++ b/src/lib/GaugeComponent/hooks/pointer.ts
@@ -106,7 +106,8 @@ const updatePointer = (percentage: number, gauge: Gauge) => {
         let currentColor = arcHooks.getArcDataByPercentage(percentage, gauge)?.color as string;
         let shouldChangeColor = currentColor != prevColor;
         if(shouldChangeColor) gauge.pointer.current.element.select("circle").attr("stroke", currentColor)
-        gauge.pointer.current.element.select("circle").attr("stroke-width", pointer.strokeWidth! * pointerRadius / 10);
+        var strokeWidth = pointer.strokeWidth! * pointerRadius / 10;
+        gauge.pointer.current.element.select("circle").attr("stroke-width", strokeWidth);
         gauge.pointer.current.context.prevColor = currentColor;
     }
 }

--- a/src/lib/GaugeComponent/types/Pointer.ts
+++ b/src/lib/GaugeComponent/types/Pointer.ts
@@ -70,4 +70,5 @@ export const defaultPointer: PointerProps = {
     hide: false,
     animationDuration: 3000,
     animationDelay: 100,
+    strokeWidth: 8
 }

--- a/src/lib/GaugeComponent/types/Pointer.ts
+++ b/src/lib/GaugeComponent/types/Pointer.ts
@@ -19,6 +19,8 @@ export interface PointerProps {
     animationDuration?: number,
     /** Animation delay in ms */
     animationDelay?: number,
+    /** Stroke width of the pointer */
+    strokeWidth?: number
 }
 export interface PointerRef {
     element: any,


### PR DESCRIPTION
When using blob pointer, 
by default border stroke width around the blob is calculated based on the width of the blob.

With this PR i would like to propose making it configurable. Imo the thickness of the stroke by default is too thick

Great job on building this component btw :)